### PR TITLE
Allow characters such as dashes in database names

### DIFF
--- a/libraries/Tester_base.php
+++ b/libraries/Tester_base.php
@@ -125,7 +125,7 @@ abstract class Tester_base
 		{
 			$this->remove_db();
 
-			$sql = 'USE '.$this->_orig_db;
+			$sql = "USE `{$this->_orig_db}`;";
 			$this->CI->db->query($sql);
 		}
 		
@@ -287,7 +287,8 @@ abstract class Tester_base
 		}
 		
 		// select the database
-		$sql = 'USE '.$this->config_item('db_name');
+		$db_name = $this->config_item('db_name');
+		$sql = "USE `$db_name`;";
 		$this->CI->db->query($sql);
 
 		if (file_exists($sql_path))


### PR DESCRIPTION
If the database defined in `$config['db_name']` has dashes in its name, the script fails with a SQL error as it's executing the USE statement.

This adds ticks around the database name.