### PR TITLE
Fix Tester_base not breaking up SQL statements on Windows

### DIFF
--- a/libraries/Tester_base.php
+++ b/libraries/Tester_base.php
@@ -297,7 +297,7 @@ abstract class Tester_base
 			$sql = preg_replace('#^/\*(.+)\*/$#U', '', $sql);
 			$sql = preg_replace('/^#(.+)$/U', '', $sql);
 		}
-		$sql_arr = explode(";\n", $sql);
+		$sql_arr = explode(";\n", str_replace("\r\n", "\n", $sql));
 
 		foreach($sql_arr as $s)
 		{


### PR DESCRIPTION
On Windows systems, the newline character `\r\n` is not being replaced by `Tester_base`, leading to SQL errors.

Fix has been shamelessly copied from FUEL-CMS itself :-) [See here](https://github.com/daylightstudio/FUEL-CMS/blob/master/fuel/modules/fuel/core/MY_DB_mysql_driver.php#L377).

## Example:

**Command:**

`php index.php tester/run fuel Fuel_cache_test.php`

**Output (before fix):**

```
[... many lines listing the whole SQL file]
/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
        Filename: C:/wamp64/www/FUEL-CMS/fuel/modules/tester/libraries/Tester_base.php
        Line Number: 307
```