### PR TITLE
Fix MY_Unit_test turning the 'results' field into a nested array

### DIFF
--- a/libraries/MY_Unit_test.php
+++ b/libraries/MY_Unit_test.php
@@ -148,19 +148,19 @@ class MY_Unit_test extends CI_Unit_test{
 			$test_data = $testtype.' - '.$test;
 			$res_data = $extype.' - '.$expected;
 		}
-		$report[] = array (
-							'test_name'			=> $test_name,
-							'test_data'		=> $test_data,
-							'res_data'		=> $res_data,
-							'result'			=> ($result === TRUE) ? 'passed' : 'failed',
-							'file'				=> $back['file'],
-							'line'				=> $back['line'],
-							'notes'				=> $notes
-						);
+		$report = array (
+			'test_name'	=> $test_name,
+			'test_data'	=> $test_data,
+			'res_data'	=> $res_data,
+			'result'	=> ($result === TRUE) ? 'passed' : 'failed',
+			'file'		=> $back['file'],
+			'line'		=> $back['line'],
+			'notes'		=> $notes
+		);
 
 		$this->results[] = $report;		
 		
-		return($this->report($this->result($report), $format));
+		return($this->report($this->result(array($report)), $format));
 	}
 	
 	// --------------------------------------------------------------------


### PR DESCRIPTION
While running tests, the `MY_Unit_test` class adds test reports to an array.

There seems to have been a typo in line 151, as with the brackets the reports array ends up being multi-dimensional, breaking code later on.

Attached text files showing the CLI output before and after the fix.

Command: `php index.php tester/run fuel Fuel_cache_test.php > result_XXXXXX.txt`

[result_before.txt](https://github.com/daylightstudio/FUEL-CMS-Tester-Module/files/1520077/result_before.txt)
[result_after.txt](https://github.com/daylightstudio/FUEL-CMS-Tester-Module/files/1520076/result_after.txt)