### PR TITLE
Encoded test names are not being validated

### DIFF
--- a/controllers/Tester.php
+++ b/controllers/Tester.php
@@ -55,7 +55,6 @@ class Tester extends Fuel_base_controller {
 			redirect(fuel_url('tools/tester'));
 		}
 		
-		$tests = array();
 		if ($is_cli)
 		{
 			if (empty($_SERVER['argv'][3]))
@@ -87,24 +86,25 @@ class Tester extends Fuel_base_controller {
 		}
 		else
 		{
-			// Only get valid tests, and eliminate potentially injected filenames
-			$tests = array_intersect($this->input->post('tests'), array_keys($this->fuel->tester->get_tests()));
-		}
-		
-		$vars = array();
-		
-		if (empty($tests))
-		{
-			$tests = $this->input->post('tests_serialized');
+			$tests = $this->input->post('tests');
+			if (empty($tests))
+			{
+				$serialized = $this->input->post('tests_serialized');
+				if (!empty($serialized))
+				{
+					$tests = unserialize(base64_decode($serialized));
+				}
+			}
 			if (empty($tests))
 			{
 				redirect(fuel_url('tools/tester'));
 			}
-			else
-			{
-				$tests = unserialize(base64_decode($tests));
-			}
+
+			// Only get valid tests, and eliminate potentially injected filenames
+			$tests = array_intersect($tests, array_keys($this->fuel->tester->get_tests()));
 		}
+		
+		$vars = array();
 		$vars['results'] = $this->fuel->tester->run($tests);
 		
 		if ($is_cli)

--- a/controllers/Tester.php
+++ b/controllers/Tester.php
@@ -49,12 +49,7 @@ class Tester extends Fuel_base_controller {
 	function run()
 	{
 		$is_cli = $this->fuel->tester->is_cli();
-		
-		if (empty($_POST) AND !$is_cli)
-		{
-			redirect(fuel_url('tools/tester'));
-		}
-		
+
 		if ($is_cli)
 		{
 			if (empty($_SERVER['argv'][3]))

--- a/controllers/Tester.php
+++ b/controllers/Tester.php
@@ -81,9 +81,11 @@ class Tester extends Fuel_base_controller {
 		}
 		else
 		{
+			// Check if the user came from the main 'Tester' tool page
 			$tests = $this->input->post('tests');
 			if (empty($tests))
 			{
+				// Check if tests are being re-run from the test results page
 				$serialized = $this->input->post('tests_serialized');
 				if (!empty($serialized))
 				{


### PR DESCRIPTION
This is kind of a follow-up to #2.

There are several issues with the current test name validation in Tester.php:

1) The injected file name validation only happens when the user comes from the main page of "Tester".

If I'm in the test results window, and hit the "Reload all" button, then there will be nothing in `$_POST['tests']`, resulting in the following:

```
<h4>A PHP Error was encountered</h4>

<p>Severity: Warning</p>
<p>Message:  array_intersect(): Argument #1 is not an array</p>
<p>Filename: controllers/Tester.php</p>
<p>Line Number: 91</p>
```

This fix ensures that tests are first collected (from `tests`, and if there's nothing there then from `tests_serialized`), and only *then* are the file names validated.

2) If you notice, the checks from line 96 onwards in the `develop` branch are done outside the `if/else` block, meaning that the POST array will be checked even if we're running from the command line (granted, only if there are actually no tests). I have not seen this functionality documented anywhere, so I'm guessing this should not be allowed via the CLI? Do let me know if I'm wrong though :-)