### PR TITLE
Fix Tester looking at wrong argument in 'argv'

### DIFF
--- a/controllers/Tester.php
+++ b/controllers/Tester.php
@@ -52,11 +52,9 @@ class Tester extends Fuel_base_controller {
 
 		if ($is_cli)
 		{
-			if (empty($_SERVER['argv'][3]))
+			if (empty($_SERVER['argv'][2]))
 			{
 				$module = 'application';
-				// $this->output->set_output(lang('tester_no_cli_arguments'));
-				// return;
 			}
 			else
 			{


### PR DESCRIPTION
If I want to run all tests in module `foo`, I should be able to do so by executing `php index.php tester/run foo`.

But `Tester` instead looks at parameter 3 (the test name!). If it's empty it resets the module to "application".