### PR TITLE
Edit backtrace index to fix line numbers in tests

### DIFF
--- a/libraries/MY_Unit_test.php
+++ b/libraries/MY_Unit_test.php
@@ -179,16 +179,11 @@ class MY_Unit_test extends CI_Unit_test {
 	 */
 	function _backtrace()
 	{
-		if (function_exists('debug_backtrace'))
-		{
-			$back = debug_backtrace();
-			$index = (string) count($back) - 6; // {{{ FUEL Added to get proper line numbers}}}
-			$file = ( ! isset($back[$index]['file'])) ? '' : $back[$index]['file'];
-			$line = ( ! isset($back[$index]['line'])) ? '' : $back[$index]['line'];
-						
-			return array('file' => $file, 'line' => $line);
-		}
-		return array('file' => 'Unknown', 'line' => 'Unknown');
+        $back = debug_backtrace();
+        return array(
+            'file' => (isset($back[2]['file']) ? $back[2]['file'] : ''),
+            'line' => (isset($back[2]['line']) ? $back[2]['line'] : '')
+        );
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
- Removed unnecessary `function_exists` call
- Updated index to fix tests in CLI and CMS

Fixes #11.

Here's what the back trace looks like:

With index 0:

```
Test Name: google_geolocate return route (short)
Result: Passed
File Name: C:\xampp\htdocs\FUEL-CMS\fuel\modules\tester\libraries\MY_Unit_test.php
Line Number: 131
Notes:
```

With index 1:

```
Test Name: google_geolocate return route (short)
Result: Passed
File Name: C:\xampp\htdocs\FUEL-CMS\fuel\modules\tester\libraries\Tester_base.php
Line Number: 84
Notes:
```

With index 2:

```
Test Name: google_geolocate return route (short)
Result: Passed
File Name: C:\xampp\htdocs\FUEL-CMS\fuel\modules\fuel\tests\Google_helper_test.php
Line Number: 78
Notes:
```

Because the `run` method is in `Tester_base` it doesn't matter whether the class under test extends `Tester_base` directly or not.